### PR TITLE
Update unavailable_entites_notification

### DIFF
--- a/unavailable_entities_notification/unavailable_entities_notification.yaml
+++ b/unavailable_entities_notification/unavailable_entities_notification.yaml
@@ -97,7 +97,7 @@ variables:
         {% endif %}
       {% endif %}
     {% endfor %}
-    {{result.entities|join(', ')}}
+    {{"⤵ \n- "}}{{result.entities|join('\n- ')}}
 
 
 # Triggers


### PR DESCRIPTION
Update unavailable_entites_notification to list entities breaking lines instead of using a comma.