### PR TITLE
fix: only one entity

### DIFF
--- a/unavailable_entities_notification/unavailable_entities_notification.yaml
+++ b/unavailable_entities_notification/unavailable_entities_notification.yaml
@@ -87,7 +87,7 @@ variables:
     {% set result = namespace(includedEntities=[], excludedEntities = []) %}
 
     {% if exclude.entity_id is defined %} 
-        {% set result.excludedEntities = result.excludedEntities + exclude.entity_id %}
+        {% set result.excludedEntities = result.excludedEntities + ([exclude.entity_id] if exclude.entity_id is string else exclude.entity_id) %}
     {% endif %}
 
     {% if exclude.device_id is defined %}


### PR DESCRIPTION
The automations was not executing when I was excluding only one entity because it can't use the `+` operator with a list and a string