### PR TITLE
Handle single device_id correctly and add support for labels and areas.

### DIFF
--- a/unavailable_entities_notification/unavailable_entities_notification.yaml
+++ b/unavailable_entities_notification/unavailable_entities_notification.yaml
@@ -91,8 +91,47 @@ variables:
     {% endif %}
 
     {% if exclude.device_id is defined %}
-      {% for device_id in exclude.device_id %}
+      {% if exclude.device_id is not list %}
+        {% set device_id_list = [exclude.device_id] %}
+      {% else %}
+        {% set device_id_list = exclude.device_id %}
+      {% endif %}
+      {% for device_id in device_id_list %}
         {% set result.excludedEntities = result.excludedEntities + device_entities(device_id) %}
+      {% endfor %}
+    {% endif %}
+
+    {% if exclude.label_id is defined %}
+      {% if exclude.label_id is not list %}
+        {% set label_id_list = [exclude.label_id] %}
+      {% else %}
+        {% set label_id_list = exclude.label_id %}
+      {% endif %}
+      {% for label_id in label_id_list %}
+        {% set result.excludedEntities = result.excludedEntities + label_entities(label_id) %}
+        {% for area in label_areas(label_id) %}
+          {% set result.excludedEntities = result.excludedEntities + area_entities(area) %}
+          {% for device in area_devices(area) %}
+              {% set result.excludedEntities = result.excludedEntities + device_entities(device) %}
+          {% endfor %}
+        {% endfor %}
+        {% for device in label_devices(label_id) %}
+            {% set result.excludedEntities = result.excludedEntities + device_entities(device) %}
+        {% endfor %}
+      {% endfor %}
+    {% endif %}
+
+    {% if exclude.area_id is defined %}
+      {% if exclude.area_id is not list %}
+        {% set area_id_list = [exclude.area_id] %}
+      {% else %}
+        {% set area_id_list = exclude.area_id %}
+      {% endif %}
+      {% for area_id in area_id_list %}
+        {% set result.excludedEntities = result.excludedEntities + area_entities(area_id) %}
+        {% for device in area_devices(area_id) %}
+            {% set result.excludedEntities = result.excludedEntities + device_entities(device) %}
+        {% endfor %}
       {% endfor %}
     {% endif %}
 


### PR DESCRIPTION
Currently,

1. If user adds a single device in the exclude list, since `exclude.device_id` is a string, iterating over it causes iterating over each character, not the device_id itself.
2. Current version doesn't support labels and areas expansion into individual entity_ids.


This PR,
1. Fixes device_id handling when only one device is in the exclude list.
3. Adds support for labels and areas expansion into individual entity_ids so they don't need to be expanded by the user.
