### PR TITLE
Update low_battery_notification.yaml

### DIFF
--- a/low_battery_notification/low_battery_notification.yaml
+++ b/low_battery_notification/low_battery_notification.yaml
@@ -173,13 +173,13 @@ variables:
 
     {# === BATTERY SENSOR DETECTION === #}
     {# Find all battery sensors below threshold, excluding those in exclusion list #}
-    {% for state in states.sensor | selectattr('attributes.device_class', 'search', 'battery') %}
+    {% for state in states.sensor if state.attributes.device_class is defined and state.attributes.device_class == 'battery' %}
       {% if 0 <= state.state | int(-1) < threshold | int and not state.entity_id in result.excludedEntities %}
         {% set result.sensors = result.sensors + [state.name ~ ' (' ~ state.state ~ ' %)'] %}
       {% endif %}
     {% endfor %}
     {# Also check binary battery sensors that are 'on' (indicating low battery) #}
-    {% for state in states.binary_sensor | selectattr('attributes.device_class', 'search', 'battery') | selectattr('state', '==', 'on') %}
+    {% for state in states.binary_sensor if state.attributes.device_class is defined and state.attributes.device_class == 'battery' and state.state == 'on' %}
       {% if not state.entity_id in result.excludedEntities %}
         {% set result.sensors = result.sensors + [state.name] %}
       {% endif %}


### PR DESCRIPTION
This should fix #35.
Warning was happening because state is a State object, where attributes are in state.attributes, not directly on the object, and when I used selectattr('attributes.device_class', 'search', 'battery'), Jinja tried to treat .attributes as a normal object and chain into .device_class. But .attributes is a ReadOnlyDict → so Jinja can’t find a .device_class attribute, and you get that warning.